### PR TITLE
Remove "value" field from validation rules for Topic

### DIFF
--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -36,6 +36,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  *          type="string"
  *      ),
  *      @OA\Property(
+ *          property="value",
+ *          description="value",
+ *          type="string"
+ *      ),
+ *      @OA\Property(
  *          property="order",
  *          description="order",
  *          type="integer",
@@ -85,6 +90,7 @@ class Topic extends Model
         'topicable_id' => 'integer',
         'topicable_type' => 'required|string|max:255',
         'order' => 'integer',
+        'value' => 'required',
     ];
 
     /**

--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -52,9 +52,6 @@ class Topic extends Model
     const CREATED_AT = 'created_at';
     const UPDATED_AT = 'updated_at';
 
-
-
-
     public $fillable = [
         'title',
         'lesson_id',
@@ -88,7 +85,6 @@ class Topic extends Model
         'topicable_id' => 'integer',
         'topicable_type' => 'required|string|max:255',
         'order' => 'integer',
-        'value' => 'required'
     ];
 
     /**


### PR DESCRIPTION
There is no "value" field in topics table or Topic model, so this rule is an error that blocks usage of topics resource rest API