### PR TITLE
Multiple tutors for single course (issue #196)

### DIFF
--- a/database/migrations/2022_01_17_000001_create_course_author_table.php
+++ b/database/migrations/2022_01_17_000001_create_course_author_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCourseAuthorTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('course_author', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('author_id');
+            $table->unsignedBigInteger('course_id');
+            $table->timestamps();
+
+            $table->foreign('author_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('course_id')->references('id')->on('courses')->onDelete('cascade');
+
+            $table->unique(['author_id', 'course_id'], 'course_author_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('course_author');
+    }
+}

--- a/database/migrations/2022_01_17_000002_migrate_single_author_to_multiple.php
+++ b/database/migrations/2022_01_17_000002_migrate_single_author_to_multiple.php
@@ -1,0 +1,43 @@
+<?php
+
+use EscolaLms\Courses\Models\Course;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MigrateSingleAuthorToMultiple extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        foreach (Course::all() as $course) {
+            if ($course->author_id) {
+                $course->authors()->syncWithoutDetaching([$course->author_id]);
+            }
+        }
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropColumn('author_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->bigInteger('author_id')->unsigned()->nullable();
+            $table->foreign('author_id')->references('id')->on('users');
+        });
+        foreach (Course::all() as $course) {
+            $course->author_id = $course->author()->id;
+            $course->save();
+        }
+    }
+}

--- a/database/migrations/2022_01_17_000002_migrate_single_author_to_multiple.php
+++ b/database/migrations/2022_01_17_000002_migrate_single_author_to_multiple.php
@@ -20,6 +20,7 @@ class MigrateSingleAuthorToMultiple extends Migration
             }
         }
         Schema::table('courses', function (Blueprint $table) {
+            $table->dropForeign('courses_author_id_foreign');
             $table->dropColumn('author_id');
         });
     }

--- a/database/seeders/CoursesPermissionSeeder.php
+++ b/database/seeders/CoursesPermissionSeeder.php
@@ -22,6 +22,7 @@ class CoursesPermissionSeeder extends Seeder
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_DELETE, 'api');
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_CREATE, 'api');
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_ATTEND, 'api');
+
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_UPDATE_OWNED, 'api');
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_DELETE_OWNED, 'api');
         Permission::findOrCreate(CoursesPermissionsEnum::COURSE_ATTEND_OWNED, 'api');

--- a/src/Enum/CoursesPermissionsEnum.php
+++ b/src/Enum/CoursesPermissionsEnum.php
@@ -11,13 +11,8 @@ class CoursesPermissionsEnum extends BasicEnum
     const COURSE_UPDATE = 'course_update';
     const COURSE_DELETE = 'course_delete';
     const COURSE_ATTEND = 'course_attend';
+
     const COURSE_UPDATE_OWNED = 'course_update-owned';
     const COURSE_DELETE_OWNED = 'course_delete-owned';
     const COURSE_ATTEND_OWNED = 'course_attend-owned';
-
-    const LESSON_UPDATE = 'update';
-    const LESSON_ATTEND = 'attend';
-
-    const TOPIC_UPDATE = 'update';
-    const TOPIC_ATTEND = 'attend';
 }

--- a/src/Events/EscolaLmsCourseTutorAssignedEvent.php
+++ b/src/Events/EscolaLmsCourseTutorAssignedEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EscolaLms\Courses\Events;
+
+class EscolaLmsCourseTutorAssignedEvent extends EscolaLmsCourseTemplateEvent
+{
+}

--- a/src/Events/EscolaLmsCourseTutorUnassignedEvent.php
+++ b/src/Events/EscolaLmsCourseTutorUnassignedEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EscolaLms\Courses\Events;
+
+class EscolaLmsCourseTutorUnassignedEvent extends EscolaLmsCourseTemplateEvent
+{
+}

--- a/src/Http/Controllers/CourseAPIController.php
+++ b/src/Http/Controllers/CourseAPIController.php
@@ -21,7 +21,6 @@ use EscolaLms\Courses\Repositories\CourseRepository;
 use EscolaLms\Courses\Services\Contracts\CourseServiceContract;
 use EscolaLms\Tags\Repository\Contracts\TagRepositoryContract;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 /**
  * Class CourseController.

--- a/src/Http/Controllers/CourseAPIController.php
+++ b/src/Http/Controllers/CourseAPIController.php
@@ -77,7 +77,7 @@ class CourseAPIController extends AppBaseController implements CourseAPISwagger
             return $this->sendError(__('Course not found'));
         }
 
-        return $this->sendResponseForResource(CourseSimpleResource::make($course->loadMissing('lessons', 'lessons.topics', 'lessons.topics.topicable', 'categories', 'tags', 'author')->loadCount('users')), __('Course retrieved successfully'));
+        return $this->sendResponseForResource(CourseSimpleResource::make($course->loadMissing('lessons', 'lessons.topics', 'lessons.topics.topicable', 'categories', 'tags', 'authors')->loadCount('users', 'authors')), __('Course retrieved successfully'));
     }
 
     public function program($id, GetCourseCurriculumAPIRequest $request): JsonResponse

--- a/src/Http/Controllers/CourseAuthorsAPIController.php
+++ b/src/Http/Controllers/CourseAuthorsAPIController.php
@@ -38,4 +38,26 @@ class CourseAuthorsAPIController extends AppBaseController implements CourseAuth
 
         return $this->sendResponseForResource(TutorResource::make($tutor), 'Tutor retrieved successfully');
     }
+
+    public function assign($id, Request $request): JsonResponse
+    {
+        $tutor = $this->courseRepositoryContract->findTutor($id);
+
+        if (empty($tutor)) {
+            return $this->sendError('Not found', 404);
+        }
+
+        return $this->sendResponseForResource(TutorResource::make($tutor), 'Tutor retrieved successfully');
+    }
+
+    public function unassign($id, Request $request): JsonResponse
+    {
+        $tutor = $this->courseRepositoryContract->findTutor($id);
+
+        if (empty($tutor)) {
+            return $this->sendError('Not found', 404);
+        }
+
+        return $this->sendResponseForResource(TutorResource::make($tutor), 'Tutor retrieved successfully');
+    }
 }

--- a/src/Http/Controllers/Swagger/CourseAPISwagger.php
+++ b/src/Http/Controllers/Swagger/CourseAPISwagger.php
@@ -79,12 +79,15 @@ interface CourseAPISwagger
      *          ),
      *      ),
      *     @OA\Parameter(
-     *          name="author_id",
-     *          description="Author ID",
+     *          name="authors",
+     *          description="Authors",
      *          required=false,
      *          in="query",
      *          @OA\Schema(
-     *              type="number",
+     *              type="array",
+     *              @OA\Items(
+     *                 ref="#/components/schemas/User"
+     *              )
      *          ),
      *      ),
      *      @OA\Parameter(
@@ -202,12 +205,15 @@ interface CourseAPISwagger
      *          ),
      *      ),
      *     @OA\Parameter(
-     *          name="author_id",
-     *          description="Author ID",
+     *          name="authors",
+     *          description="Authors",
      *          required=false,
      *          in="query",
      *          @OA\Schema(
-     *              type="number",
+     *              type="array",
+     *              @OA\Items(
+     *                 ref="#/components/schemas/User"
+     *              )
      *          ),
      *      ),
      *      @OA\Parameter(

--- a/src/Http/Requests/AssignAuthorApiRequest.php
+++ b/src/Http/Requests/AssignAuthorApiRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EscolaLms\Courses\Http\Requests;
+
+use EscolaLms\Core\Enums\UserRole;
+use EscolaLms\Courses\Models\Course;
+use EscolaLms\Courses\Models\User;
+use EscolaLms\Courses\Repositories\Contracts\CourseRepositoryContract;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AssignAuthorApiRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = auth()->user();
+        return isset($user) ? $user->can('update', $this->getCourse()) : false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function getCourse(): ?Course
+    {
+        return Course::find($this->route('course'));
+    }
+
+    public function getTutor(): ?User
+    {
+        return User::find($this->route('id'));
+    }
+}

--- a/src/Http/Requests/CreateCourseAPIRequest.php
+++ b/src/Http/Requests/CreateCourseAPIRequest.php
@@ -29,7 +29,7 @@ class CreateCourseAPIRequest extends FormRequest
         $rules = array_merge(Course::$rules, [
             'title' => ['required', 'string', "min:3"],
         ]);
-        $rules['author_id'][] = new ValidAuthor();
+        $rules['authors.*'][] = new ValidAuthor();
         return $rules;
     }
 }

--- a/src/Http/Requests/UpdateCourseAPIRequest.php
+++ b/src/Http/Requests/UpdateCourseAPIRequest.php
@@ -28,7 +28,7 @@ class UpdateCourseAPIRequest extends FormRequest
     public function rules()
     {
         $rules = Course::$rules;
-        $rules['author_id'][] = new ValidAuthor();
+        $rules['authors.*'][] = new ValidAuthor();
         return $rules;
     }
 }

--- a/src/Http/Resources/Admin/CourseWithProgramAdminResource.php
+++ b/src/Http/Resources/Admin/CourseWithProgramAdminResource.php
@@ -44,6 +44,7 @@ class CourseWithProgramAdminResource extends JsonResource
             'base_price' => $course->base_price,
             'duration' => $course->duration,
             'author_id' => $course->author_id,
+            'authors' => $course->authors,
             'scorm_sco_id' => $course->scorm_sco_id,
             'scorm_sco' => $this->when($course->scorm_sco_id !== null, fn () => ScormScoResource::make($course->scormSco)),
             'active' => $course->active,

--- a/src/Http/Resources/CourseResource.php
+++ b/src/Http/Resources/CourseResource.php
@@ -33,6 +33,7 @@ class CourseResource extends JsonResource
             'base_price' =>  $course->base_price,
             'duration' =>  $course->duration,
             'author_id' => $course->author_id,
+            'authors' => $course->authors,
             'scorm_sco_id' => $course->scorm_sco_id,
             'active' =>  $course->active,
             'subtitle' =>  $course->subtitle,

--- a/src/Http/Resources/CourseSimpleResource.php
+++ b/src/Http/Resources/CourseSimpleResource.php
@@ -23,6 +23,7 @@ class CourseSimpleResource extends JsonResource
             'duration' => $this->duration,
             'author_id' => $this->author_id,
             'author' => $this->author,
+            'authors' => $this->authors,
             'active' => $this->active,
             'subtitle' => $this->subtitle,
             'language' => $this->language,

--- a/src/Http/Resources/CourseWithProgramResource.php
+++ b/src/Http/Resources/CourseWithProgramResource.php
@@ -43,6 +43,7 @@ class CourseWithProgramResource extends JsonResource
             'base_price' =>  $course->base_price,
             'duration' =>  $course->duration,
             'author_id' => $course->author_id,
+            'authors' => $course->authors,
             'scorm_sco_id' => $course->scorm_sco_id,
             'scorm_sco' => $this->when($course->scorm_sco_id !== null, fn () => ScormScoResource::make($course->scormSco)),
             'active' =>  $course->active,

--- a/src/Http/Resources/TutorResource.php
+++ b/src/Http/Resources/TutorResource.php
@@ -14,7 +14,7 @@ class TutorResource extends JsonResource
             'last_name' => $this->last_name,
             'email' => $this->email,
             'path_avatar' => $this->path_avatar,
-            'bio' => $this->bio
+            'bio' => $this->bio,
         ];
     }
 }

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -256,9 +256,29 @@ class Course extends Model
 
     protected $appends = ['image_url', 'video_url', 'poster_url'];
 
-    public function author(): BelongsTo
+    public function authors(): BelongsToMany
     {
-        return $this->belongsTo(User::class, 'author_id');
+        return $this->belongsToMany(User::class);
+    }
+
+    /** Backwards compatibility */
+    public function getAuthorAttribute(): ?User
+    {
+        return $this->authors()->first();
+    }
+
+    public function getAuthorIdAttribute(): ?int
+    {
+        $author = $this->author();
+        if ($author) {
+            return $author->id;
+        }
+        return $this->getOriginal('author_id');
+    }
+
+    public function hasAuthor(User $user): bool
+    {
+        return $this->author_id === $user->id || !is_null($this->authors()->where('id', $user->id)->first());
     }
 
     public function lessons(): HasMany

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -395,11 +395,6 @@ class Course extends Model
 
     public function getMorphClass()
     {
-        return self::class;
-    }
-
-    public function getMorphClass()
-    {
         return \EscolaLms\Courses\Models\Course::class;
     }
 }

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -68,11 +68,6 @@ use Peopleaps\Scorm\Model\ScormScoModel;
  *          description="duration",
  *          type="string"
  *      ),
- *      @OA\Property(
- *          property="author_id",
- *          description="author_id",
- *          type="integer",
- *      ),
  *     @OA\Property(
  *          property="scorm_sco_id",
  *          description="scorm_sco_id",
@@ -171,6 +166,9 @@ class Course extends Model
 
     public $table = 'courses';
 
+    /** Backwards compatibility */
+    protected ?int $author_id = null;
+
     public $fillable = [
         'title',
         'summary',
@@ -207,7 +205,6 @@ class Course extends Model
         'video_path' => 'string',
         'base_price' => 'integer',
         'duration' => 'string',
-        'author_id' => 'integer',
         'active' => 'boolean',
         'subtitle' => 'string',
         'language' => 'string',
@@ -235,7 +232,8 @@ class Course extends Model
         'video_path' => 'nullable|string|max:255',
         'base_price' => 'nullable|integer|min:0',
         'duration' => 'nullable|string|max:255',
-        'author_id' => ['nullable', 'exists:users,id'],
+        'authors' => ['nullable', 'array'],
+        'authors.*' => ['integer'],
         'image' => 'file|image',
         'video' => 'file|mimes:mp4,ogg,webm',
         'active' => 'boolean',
@@ -258,7 +256,7 @@ class Course extends Model
 
     public function authors(): BelongsToMany
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class, 'course_author', 'course_id', 'author_id')->using(CourseAuthorPivot::class);
     }
 
     /** Backwards compatibility */
@@ -267,18 +265,34 @@ class Course extends Model
         return $this->authors()->first();
     }
 
+    /** Backwards compatibility */
     public function getAuthorIdAttribute(): ?int
     {
-        $author = $this->author();
+        $author = $this->author;
         if ($author) {
             return $author->id;
         }
-        return $this->getOriginal('author_id');
+        return $this->author_id;
     }
 
-    public function hasAuthor(User $user): bool
+    /** Backwards compatibility */
+    public function setAuthorAttribute(User $author)
     {
-        return $this->author_id === $user->id || !is_null($this->authors()->where('id', $user->id)->first());
+        $this->setAuthorIdAttribute($author->getKey());
+    }
+
+    /** Backwards compatibility */
+    public function setAuthorIdAttribute(?int $author_id)
+    {
+        if ($this->exists && !is_null($author_id)) {
+            $this->authors()->syncWithoutDetaching([$author_id]);
+        }
+        $this->author_id = $author_id;
+    }
+
+    public function hasAuthor(User $author): bool
+    {
+        return !is_null($this->authors()->where('author_id', $author->id)->first());
     }
 
     public function lessons(): HasMany
@@ -371,5 +385,16 @@ class Course extends Model
                 $course->findable = config('escolalms_courses.platform_visibility', PlatformVisibility::VISIBILITY_PUBLIC) === PlatformVisibility::VISIBILITY_PUBLIC;
             }
         });
+        /** Backwards compatibility */
+        self::saved(function (Course $course) {
+            if ($course->author_id) {
+                $course->authors()->syncWithoutDetaching([$course->author_id]);
+            }
+        });
+    }
+
+    public function getMorphClass()
+    {
+        return self::class;
     }
 }

--- a/src/Models/CourseAuthorPivot.php
+++ b/src/Models/CourseAuthorPivot.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EscolaLms\Courses\Models;
+
+use EscolaLms\Core\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class CourseAuthorPivot extends Pivot
+{
+    protected $table = 'course_author';
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function course(): BelongsTo
+    {
+        return $this->belongsTo(Course::class);
+    }
+}

--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -5,6 +5,7 @@ namespace EscolaLms\Courses\Models;
 use EscolaLms\Courses\Database\Factories\TopicFactory;
 use EscolaLms\Courses\Facades\Topic as TopicFacade;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -188,10 +189,10 @@ class Topic extends Model
     public function getStorageDirectoryAttribute(): string
     {
         if ($this->lesson && $this->lesson->course_id) {
-            return 'course/'.$this->lesson->course_id.'/topic/'.$this->getKey().'/';
+            return 'course/' . $this->lesson->course_id . '/topic/' . $this->getKey() . '/';
         }
 
-        return 'topic/'.$this->getKey().'/';
+        return 'topic/' . $this->getKey() . '/';
     }
 
     protected static function booted()

--- a/src/Models/Traits/HasAuthoredCourses.php
+++ b/src/Models/Traits/HasAuthoredCourses.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EscolaLms\Courses\Models\Traits;
+
+use EscolaLms\Courses\Models\Course;
+use EscolaLms\Courses\Models\CourseAuthorPivot;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+trait HasAuthoredCourses
+{
+    public function authoredCourses(): BelongsToMany
+    {
+        return $this->belongsToMany(Course::class, 'course_author', 'author_id', 'course_id')->using(CourseAuthorPivot::class);
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -6,13 +6,13 @@ use EscolaLms\Auth\Models\Traits\HasGroups;
 use EscolaLms\Auth\Models\Traits\HasOnboardingStatus;
 use EscolaLms\Auth\Models\Traits\UserHasSettings;
 use EscolaLms\Auth\Models\User as AuthUser;
+use EscolaLms\Courses\Models\Traits\HasAuthoredCourses;
 use EscolaLms\Courses\Models\Traits\HasCourses;
 use EscolaLms\Courses\Tests\Database\Factories\UserFactory;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class User extends AuthUser
 {
-    use HasCourses, HasGroups, HasOnboardingStatus, UserHasSettings;
+    use HasCourses, HasAuthoredCourses, HasGroups, HasOnboardingStatus, UserHasSettings;
 
     protected function getTraitOwner(): self
     {

--- a/src/Policies/CoursesPolicy.php
+++ b/src/Policies/CoursesPolicy.php
@@ -2,11 +2,10 @@
 
 namespace EscolaLms\Courses\Policies;
 
+use EscolaLms\Core\Models\User;
 use EscolaLms\Courses\Enum\CoursesPermissionsEnum;
 use EscolaLms\Courses\Models\Course;
-use EscolaLms\Core\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Illuminate\Auth\Access\Response;
 
 class CoursesPolicy
 {
@@ -33,12 +32,8 @@ class CoursesPolicy
         if ($user->can(CoursesPermissionsEnum::COURSE_UPDATE)) {
             return true;
         }
-        if ($user->can(CoursesPermissionsEnum::COURSE_UPDATE_OWNED) && $course->author_id === $user->id) {
-            return true;
-        }
-        if ($user->can(CoursesPermissionsEnum::COURSE_UPDATE_OWNED) && $course->author_id !== $user->id) {
-            return false;
-            //return Response::deny('You do not own this course.');
+        if ($user->can(CoursesPermissionsEnum::COURSE_UPDATE_OWNED)) {
+            return $course->hasAuthor($user);
         }
 
         return false;
@@ -69,12 +64,8 @@ class CoursesPolicy
         if ($user->can(CoursesPermissionsEnum::COURSE_DELETE)) {
             return true;
         }
-        if ($user->can(CoursesPermissionsEnum::COURSE_DELETE_OWNED) && $course->author_id === $user->id) {
-            return true;
-        }
-        if ($user->can(CoursesPermissionsEnum::COURSE_DELETE_OWNED) && $course->author_id !== $user->id) {
-            return false;
-            //return Response::deny('You do not own this course.');
+        if ($user->can(CoursesPermissionsEnum::COURSE_DELETE_OWNED)) {
+            return $course->hasAuthor($user);
         }
 
         return false;
@@ -104,8 +95,8 @@ class CoursesPolicy
         if ($user->can(CoursesPermissionsEnum::COURSE_ATTEND)) {
             return true;
         }
-        if ($user->can(CoursesPermissionsEnum::COURSE_ATTEND_OWNED) && $course->author_id === $user->id) {
-            return true;
+        if ($user->can(CoursesPermissionsEnum::COURSE_ATTEND_OWNED)) {
+            return $course->hasAuthor($user);
         }
 
         return $course->is_active && ($course->users()->where('users.id', $user->getKey())->exists() || $course->groups()->whereHas('users', fn ($query) => $query->where('users.id', $user->getKey()))->exists());

--- a/src/Policies/LessonPolicy.php
+++ b/src/Policies/LessonPolicy.php
@@ -3,7 +3,6 @@
 namespace EscolaLms\Courses\Policies;
 
 use EscolaLms\Core\Models\User;
-use EscolaLms\Courses\Enum\CoursesPermissionsEnum;
 use EscolaLms\Courses\Models\Lesson;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Support\Facades\Gate;
@@ -14,26 +13,26 @@ class LessonPolicy
 
     public function view(User $user, Lesson $lesson): bool
     {
-        return $user->can(CoursesPermissionsEnum::LESSON_UPDATE, $lesson->course);
+        return $user->can('update', $lesson->course); // this calls `update` method from CoursePolicy
     }
 
     public function update(User $user, Lesson $lesson): bool
     {
-        return $user->can(CoursesPermissionsEnum::LESSON_UPDATE, $lesson->course);
+        return $user->can('update', $lesson->course); // this calls `update` method from CoursePolicy
     }
 
     public function delete(User $user, Lesson $lesson): bool
     {
-        return $user->can(CoursesPermissionsEnum::LESSON_UPDATE, $lesson->course);
+        return $user->can('update', $lesson->course); // this calls `update` method from CoursePolicy
     }
 
     public function attend(?User $user, Lesson $lesson): bool
     {
-        return Gate::check(CoursesPermissionsEnum::LESSON_ATTEND, $lesson->course);
+        return Gate::check('attend', $lesson->course); // this calls `attend` method from CoursePolicy
     }
 
     public function clone(User $user, Lesson $lesson): bool
     {
-        return $user->can('update', $lesson->course);
+        return $user->can('update', $lesson->course); // this calls `update` method from CoursePolicy
     }
 }

--- a/src/Policies/TopicPolicy.php
+++ b/src/Policies/TopicPolicy.php
@@ -3,7 +3,6 @@
 namespace EscolaLms\Courses\Policies;
 
 use EscolaLms\Core\Models\User;
-use EscolaLms\Courses\Enum\CoursesPermissionsEnum;
 use EscolaLms\Courses\Models\Topic;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Support\Facades\Gate;
@@ -14,26 +13,26 @@ class TopicPolicy
 
     public function view(User $user, Topic $topic): bool
     {
-        return $user->can(CoursesPermissionsEnum::TOPIC_UPDATE, $topic->lesson);
+        return $user->can('update', $topic->lesson); // this calls `update` method from LessonPolicy
     }
 
     public function update(User $user, Topic $topic): bool
     {
-        return $user->can(CoursesPermissionsEnum::TOPIC_UPDATE, $topic->lesson);
+        return $user->can('update', $topic->lesson); // this calls `update` method from LessonPolicy
     }
 
     public function delete(User $user, Topic $topic): bool
     {
-        return $user->can(CoursesPermissionsEnum::TOPIC_UPDATE, $topic->lesson);
+        return $user->can('update', $topic->lesson); // this calls `update` method from LessonPolicy
     }
 
     public function attend(?User $user, Topic $topic): bool
     {
-        return Gate::check(CoursesPermissionsEnum::TOPIC_ATTEND, $topic->lesson);
+        return Gate::check('attend', $topic->lesson); // this calls `attend` method from LessonPolicy
     }
 
     public function clone(User $user, Topic $topic): bool
     {
-        return $user->can('update', $topic->lesson);
+        return $user->can('update', $topic->lesson); // this calls `update` method from LessonPolicy
     }
 }

--- a/src/Repositories/Contracts/CourseRepositoryContract.php
+++ b/src/Repositories/Contracts/CourseRepositoryContract.php
@@ -2,9 +2,9 @@
 
 namespace EscolaLms\Courses\Repositories\Contracts;
 
-use EscolaLms\Core\Models\User;
 use EscolaLms\Core\Repositories\Contracts\BaseRepositoryContract;
 use EscolaLms\Courses\Models\Course;
+use EscolaLms\Courses\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
@@ -20,4 +20,8 @@ interface CourseRepositoryContract extends BaseRepositoryContract
     public function getById(int $id): Course;
 
     public function deleteModel(Course $course): ?bool;
+
+    public function syncAuthors(Course $course, array $authors = []): void;
+    public function addAuthor(Course $course, User $author): void;
+    public function removeAuthor(Course $course, User $author): void;
 }

--- a/src/Repositories/CourseRepository.php
+++ b/src/Repositories/CourseRepository.php
@@ -189,7 +189,7 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
             event(new EscolaLmsCoursedPublishedTemplateEvent(Auth::user(), $model));
         }
 
-        $this->syncAuthors($model, $input['authors'] ?? [Auth::id()]);
+        $this->syncAuthors($model, $input['authors'] ?? (Auth::user() ? [Auth::id()] : []));
 
         return $model;
     }
@@ -257,7 +257,7 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
 
     public function syncAuthors(Course $course, array $authors = []): void
     {
-        if (!Auth::user()->can(CoursesPermissionsEnum::COURSE_UPDATE)) {
+        if (Auth::user() && !Auth::user()->can(CoursesPermissionsEnum::COURSE_UPDATE)) {
             $authors = array_unique(array_merge($authors, $course->authors()->pluck('author_id')->all(), [Auth::id()])); // only admin can remove other authors?
         }
 

--- a/src/Repositories/CourseRepository.php
+++ b/src/Repositories/CourseRepository.php
@@ -3,19 +3,21 @@
 namespace EscolaLms\Courses\Repositories;
 
 use EscolaLms\Categories\Models\Category;
-use EscolaLms\Core\Enums\UserRole;
-use EscolaLms\Core\Models\User;
+use EscolaLms\Courses\Enum\CoursesPermissionsEnum;
 use EscolaLms\Courses\Events\EscolaLmsCoursedPublishedTemplateEvent;
+use EscolaLms\Courses\Events\EscolaLmsCourseTutorAssignedEvent;
+use EscolaLms\Courses\Events\EscolaLmsCourseTutorUnassignedEvent;
 use EscolaLms\Courses\Models\Course;
+use EscolaLms\Courses\Models\User;
 use EscolaLms\Courses\Repositories\Contracts\CourseRepositoryContract;
 use EscolaLms\Courses\Repositories\Contracts\LessonRepositoryContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
@@ -39,7 +41,6 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         'video_path',
         'base_price',
         'duration',
-        'author_id',
         'active',
         'scorm_sco_id',
         'poster_path',
@@ -147,10 +148,6 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
      */
     public function create(array $input): Model
     {
-        if (!isset($input['author_id']) || !(Auth::user() && Auth::user()->hasRole(UserRole::ADMIN))) {
-            $input['author_id'] = Auth::id();
-        }
-
         $model = $this->model->newInstance($input);
 
         $model->save();
@@ -183,6 +180,9 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         if ($model->is_active && Auth::user()) {
             event(new EscolaLmsCoursedPublishedTemplateEvent(Auth::user(), $model));
         }
+
+        $this->syncAuthors($model, $input['authors'] ?? [Auth::id()]);
+
         return $model;
     }
 
@@ -198,9 +198,6 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         $model = $query->findOrFail($id);
 
         $isActive = $model->is_active;
-        if (isset($input['author_id']) && Auth::user() && !Auth::user()->hasRole(UserRole::ADMIN)) {
-            $input['author_id'] = Auth::id();
-        }
 
         if (isset($input['video'])) {
             /** @var UploadedFile $video */
@@ -242,7 +239,44 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         if ($isActive !== $model->is_active && $model->is_active && Auth::user()) {
             event(new EscolaLmsCoursedPublishedTemplateEvent(Auth::user(), $model));
         }
+
+        if (isset($input['authors'])) {
+            $this->syncAuthors($model, $input['authors']);
+        }
+
         return $model;
+    }
+
+    public function syncAuthors(Course $course, array $authors = []): void
+    {
+        if (!Auth::user()->can(CoursesPermissionsEnum::COURSE_UPDATE)) {
+            $authors = array_unique(array_merge($authors, $course->authors()->pluck('author_id')->all(), [Auth::id()])); // only admin can remove other authors?
+        }
+
+        $syncResults = $course->authors()->sync($authors);
+
+        foreach ($syncResults['attached'] as $attached) {
+            event(new EscolaLmsCourseTutorAssignedEvent(User::find($attached), $course));
+        }
+        foreach ($syncResults['detached'] as $detached) {
+            event(new EscolaLmsCourseTutorUnassignedEvent(User::find($detached), $course));
+        }
+    }
+
+    public function addAuthor(Course $course, User $author): void
+    {
+        if (!in_array($author->getKey(), $course->authors()->pluck('author_id')->all())) {
+            $course->authors()->attach($author->getKey());
+            event(new EscolaLmsCourseTutorAssignedEvent($author, $course));
+        }
+    }
+
+    public function removeAuthor(Course $course, User $author): void
+    {
+        if ($course->authors()->detach([$author->getKey()])) {
+            event(new EscolaLmsCourseTutorUnassignedEvent($author, $course));
+            $course->author_id = null;
+        }
     }
 
     public function getById(int $id): Course
@@ -277,14 +311,9 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         return true;
     }
 
-    private function tutors()
+    private function tutors(): Builder
     {
-        return User::whereExists(function ($query) {
-            $query->select(DB::raw(1))
-                ->from('courses')
-                ->where('active', 1)
-                ->whereColumn('courses.author_id', 'users.id');
-        })->select(['id', 'first_name', 'last_name', 'email', 'path_avatar', 'bio']);
+        return User::has('authoredCourses')->select(['id', 'first_name', 'last_name', 'email', 'path_avatar', 'bio']);
     }
 
     public function findTutors(): Collection

--- a/src/Services/CourseService.php
+++ b/src/Services/CourseService.php
@@ -50,7 +50,7 @@ class CourseService implements CourseServiceContract
         $query = $this->courseRepository->allQueryBuilder(
             $search,
             $criteria
-        )->with(['categories', 'tags', 'author'])
+        )->with(['categories', 'tags', 'authors'])
             ->withCount(['lessons', 'users', 'topics']);
 
         return $query;

--- a/src/routes.php
+++ b/src/routes.php
@@ -35,6 +35,9 @@ Route::group(['middleware' => ['auth:api'], 'prefix' => 'api/admin'], function (
 
     Route::get('/courses/search/tags', [CourseAPIController::class, 'searchByTag']);
     Route::get('/courses/search/{category_id}', [CourseAPIController::class, 'category']);
+
+    Route::post('/tutors/{id}/assign/{course}', [CourseAuthorsAPIController::class, 'assign']);
+    Route::post('/tutors/{id}/unassign/{course}', [CourseAuthorsAPIController::class, 'unassign']);
 });
 
 // user endpoints

--- a/tests/APIs/CourseAccessApiTest.php
+++ b/tests/APIs/CourseAccessApiTest.php
@@ -28,10 +28,10 @@ class CourseAccessApiTest extends TestCase
         $this->user->guard_name = 'api';
         $this->user->assignRole('tutor');
         $this->course = Course::factory()->create([
-            'author_id' => $this->user->id,
             'base_price' => 1337,
             'active' => true,
         ]);
+        $this->course->authors()->sync($this->user);
 
         Notification::fake();
     }
@@ -157,7 +157,6 @@ class CourseAccessApiTest extends TestCase
         $this->response = $this->actingAs($this->user, 'api')->post('/api/admin/courses/' . $this->course->id . '/access/add/', [
             'users' => [$student->getKey()]
         ]);
-
         $this->response->assertOk();
         Event::assertDispatched(EscolaLmsCourseAccessStartedTemplateEvent::class);
         $this->assertUserCanReadProgram($student, $this->course);

--- a/tests/APIs/CourseAdminApiTest.php
+++ b/tests/APIs/CourseAdminApiTest.php
@@ -6,7 +6,6 @@ use EscolaLms\Categories\Models\Category;
 use EscolaLms\Core\Tests\CreatesUsers;
 use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
 use EscolaLms\Courses\Events\EscolaLmsCoursedPublishedTemplateEvent;
-use EscolaLms\Courses\Events\EscolaLmsCourseStartedTemplateEvent;
 use EscolaLms\Courses\Models\Course;
 use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Models\Topic;
@@ -192,7 +191,7 @@ class CourseAdminApiTest extends TestCase
         $editedCourse = Course::factory()->make()->toArray();
 
         $student = $this->makeStudent();
-        $editedCourse['author_id'] = $student->getKey();
+        $editedCourse['authors'][] = $student->getKey();
 
         $this->response = $this->actingAs($this->user, 'api')->json(
             'PUT',
@@ -201,7 +200,7 @@ class CourseAdminApiTest extends TestCase
         );
 
         $this->response->assertStatus(422);
-        $this->response->assertInvalid('author_id');
+        $this->response->assertInvalid('authors.0');
     }
 
     /**

--- a/tests/APIs/CourseAdminApiTest.php
+++ b/tests/APIs/CourseAdminApiTest.php
@@ -297,9 +297,9 @@ class CourseAdminApiTest extends TestCase
 
     public function test_search_course_by_tag()
     {
-        $course = Course::factory()->create();
-        $course2 = Course::factory()->create();
-        $course3 = Course::factory()->create();
+        $course = Course::factory()->create(['active' => true, 'findable' => true]);
+        $course2 = Course::factory()->create(['active' => true, 'findable' => true]);
+        $course3 = Course::factory()->create(['active' => true, 'findable' => true]);
 
         $tags = ['Lorem', 'Ipsum', "LoremIpsum"];
         $tags2 = ['Foo', 'Bar', 'FooBar'];
@@ -615,7 +615,7 @@ class CourseAdminApiTest extends TestCase
         ]);
     }
 
-    public function test_unique_tags_courses() : void
+    public function test_unique_tags_courses(): void
     {
         $courseActive = Course::factory(['active' => true])->create();
         $courseUnActive = Course::factory(['active' => false])->create();

--- a/tests/APIs/CourseAdministrableConfigTest.php
+++ b/tests/APIs/CourseAdministrableConfigTest.php
@@ -56,18 +56,24 @@ class CourseAdministrableConfigTest extends TestCase
         $this->response->assertJsonFragment([
             'escolalms_courses' => [
                 'platform_visibility' => [
+                    'full_key' => 'escolalms_courses.platform_visibility',
+                    'key' => 'platform_visibility',
                     'rules' => ['required', 'string', 'in:public,registered'],
                     'public' => true,
                     'readonly' => false,
                     'value' => 'public',
                 ],
                 'reminder_of_deadline_count_days' => [
+                    'full_key' => 'escolalms_courses.reminder_of_deadline_count_days',
+                    'key' => 'reminder_of_deadline_count_days',
                     'rules' => ['integer', 'min: 1'],
                     'public' => true,
                     'readonly' => false,
                     'value' => CoursesConstant::REMINDER_OF_DEADLINE_COUNT_DAYS,
                 ],
                 'course_visibility' => [
+                    'full_key' => 'escolalms_courses.course_visibility',
+                    'key' => 'course_visibility',
                     'rules' => ['required', 'string', 'in:' . implode(',', CourseVisibilityEnum::getValues())],
                     'public' => true,
                     'readonly' => false,

--- a/tests/APIs/CourseTutorApiTest.php
+++ b/tests/APIs/CourseTutorApiTest.php
@@ -3,6 +3,7 @@
 namespace EscolaLms\Courses\Tests\APIs;
 
 use EscolaLms\Categories\Models\Category;
+use EscolaLms\Core\Tests\CreatesUsers;
 use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
 use EscolaLms\Courses\Models\Course;
 use EscolaLms\Courses\Tests\TestCase;
@@ -10,6 +11,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class CourseTutorApiTest extends TestCase
 {
+    use CreatesUsers;
     use DatabaseTransactions;
 
     /**
@@ -116,7 +118,6 @@ class CourseTutorApiTest extends TestCase
 
         $editedCourse = Course::factory()->make()->toArray();
 
-
         $this->response = $this->actingAs($this->user, 'api')->json(
             'PUT',
             '/api/admin/courses/' . $course->id,
@@ -193,5 +194,43 @@ class CourseTutorApiTest extends TestCase
         );
 
         $this->response->assertStatus(200);
+    }
+
+    public function test_assign_tutor()
+    {
+        $admin = $this->makeAdmin();
+
+        /** @var Course $course */
+        $course = Course::factory()->create();
+        $this->assertFalse($course->hasAuthor($this->user));
+
+        $this->response = $this->actingAs($admin, 'api')->json(
+            'POST',
+            '/api/admin/tutors/' . $this->user->id . '/assign/' . $course->id
+        );
+        $this->response->assertOk();
+
+        $course->refresh();
+        $this->assertTrue($course->hasAuthor($this->user));
+    }
+
+    public function test_unassign_tutor()
+    {
+        $admin = $this->makeAdmin();
+
+        /** @var Course $course */
+        $course = Course::factory()->create([
+            'author_id' => $this->user->id
+        ]);
+        $this->assertTrue($course->hasAuthor($this->user));
+
+        $this->response = $this->actingAs($admin, 'api')->json(
+            'POST',
+            '/api/admin/tutors/' . $this->user->id . '/unassign/' . $course->id
+        );
+        $this->response->assertOk();
+
+        $course->refresh();
+        $this->assertFalse($course->hasAuthor($this->user));
     }
 }

--- a/tests/APIs/CourseTutorApiTest.php
+++ b/tests/APIs/CourseTutorApiTest.php
@@ -201,7 +201,9 @@ class CourseTutorApiTest extends TestCase
         $admin = $this->makeAdmin();
 
         /** @var Course $course */
-        $course = Course::factory()->create();
+        $course = Course::factory()->create([
+            'author_id' => null
+        ]);
         $this->assertFalse($course->hasAuthor($this->user));
 
         $this->response = $this->actingAs($admin, 'api')->json(

--- a/tests/APIs/LessonTutorApiTest.php
+++ b/tests/APIs/LessonTutorApiTest.php
@@ -10,6 +10,7 @@ use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Models\Course;
 
 use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
+use Illuminate\Support\Facades\Event;
 
 class LessonTutorApiTest extends TestCase
 {
@@ -125,7 +126,9 @@ class LessonTutorApiTest extends TestCase
 
     public function test_clone_lesson()
     {
-        $course = Course::factory()->create();
+        $course = Course::factory()->create([
+            'author_id' => $this->user->getKey(),
+        ]);
         $lesson = Lesson::factory()->create([
             'course_id' => $course->getKey(),
         ]);

--- a/tests/APIs/TopicTutorApiTest.php
+++ b/tests/APIs/TopicTutorApiTest.php
@@ -42,7 +42,7 @@ class TopicTutorApiTest extends TestCase
 
         $this->response = $this->actingAs($this->user, 'api')->json(
             'GET',
-            '/api/admin/topics/'.$topic->id
+            '/api/admin/topics/' . $topic->id
         );
 
         $this->assertApiResponse($topic->toArray());
@@ -68,13 +68,13 @@ class TopicTutorApiTest extends TestCase
 
         $this->response = $this->actingAs($this->user, 'api')->json(
             'DELETE',
-            '/api/admin/topics/'.$topic->id
+            '/api/admin/topics/' . $topic->id
         );
 
         $this->assertApiSuccess();
         $this->response = $this->actingAs($this->user, 'api')->json(
             'GET',
-            '/api/admin/topics/'.$topic->id
+            '/api/admin/topics/' . $topic->id
         );
 
         $this->response->assertStatus(404);
@@ -94,13 +94,13 @@ class TopicTutorApiTest extends TestCase
 
         $this->response = $this->actingAs($this->user, 'api')->json(
             'DELETE',
-            '/api/admin/courses/'.$course->id
+            '/api/admin/courses/' . $course->id
         );
 
         $this->assertApiSuccess();
         $this->response = $this->actingAs($this->user, 'api')->json(
             'GET',
-            '/api/admin/topics/'.$topic->id
+            '/api/admin/topics/' . $topic->id
         );
 
         $this->response->assertStatus(404);
@@ -124,7 +124,7 @@ class TopicTutorApiTest extends TestCase
 
         $this->response = $this->actingAs($this->user, 'api')->json(
             'DELETE',
-            '/api/admin/topics/'.$topic->id
+            '/api/admin/topics/' . $topic->id
         );
 
         $this->response->assertStatus(403);
@@ -152,7 +152,10 @@ class TopicTutorApiTest extends TestCase
     {
         Storage::fake('local');
 
-        $course = Course::factory()->create();
+        $course = Course::factory()->create([
+            'author_id' => $this->user->id,
+        ]);
+
         $lesson = Lesson::factory()->create([
             'course_id' => $course->getKey(),
         ]);

--- a/tests/Notifications/NotificationsTest.php
+++ b/tests/Notifications/NotificationsTest.php
@@ -91,7 +91,7 @@ class NotificationsTest extends TestCase
     public function testUserAssignedToCourseNotification()
     {
         Notification::fake();
-        Event::fake();
+        Event::fake([EscolaLmsCourseAccessStartedTemplateEvent::class, EscolaLmsCourseAssignedTemplateEvent::class]);
 
         $course = Course::factory()->create([
             'author_id' => $this->user->id,
@@ -117,7 +117,7 @@ class NotificationsTest extends TestCase
     public function testUserUnassignedFromCourseNotification()
     {
         Notification::fake();
-        Event::fake();
+        Event::fake(EscolaLmsCourseUnassignedTemplateEvent::class);
 
         $course = Course::factory()->create([
             'author_id' => $this->user->id,

--- a/tests/Repositories/CourseRepositoryTest.php
+++ b/tests/Repositories/CourseRepositoryTest.php
@@ -35,7 +35,7 @@ class CourseRepositoryTest extends TestCase
         $this->assertArrayHasKey('id', $createdCourse);
         $this->assertNotNull($createdCourse['id'], 'Created Course must have id specified');
         $this->assertNotNull(Course::find($createdCourse['id']), 'Course with given id must be in DB');
-        $course['author_id'] = $createdCourse['author_id'];
+
         $this->assertModelData($course, $createdCourse);
     }
 


### PR DESCRIPTION
I've tried to make this as backwards compatible as possible, so other packages that try to access `->author` or `->author_id` properties of Course model should still work (probably).

Issue #196 
