### PR TITLE
Additional tests (removing all authors) and test fixes

### DIFF
--- a/src/Http/Controllers/CourseAPIController.php
+++ b/src/Http/Controllers/CourseAPIController.php
@@ -141,6 +141,6 @@ class CourseAPIController extends AppBaseController implements CourseAPISwagger
         $tags = $this->tagRepositoryContract->uniqueTagsFromActiveCourses();
         return $tags ?
             $this->sendResponse($tags, 'Tags unique fetched successfully') :
-            $this->sendError('Tags not found', 404) ;
+            $this->sendError('Tags not found', 404);
     }
 }

--- a/src/Repositories/CourseRepository.php
+++ b/src/Repositories/CourseRepository.php
@@ -130,8 +130,8 @@ class CourseRepository extends BaseRepository implements CourseRepositoryContrac
         }
 
         /** search by TAG */
-        if (isset($search['tag'])) {
-            $tags = is_array($search['tag']) ? $search['tag'] : array_filter([$search['tag']]);
+        if (array_key_exists('tag', $search)) {
+            $tags = array_filter(is_array($search['tag']) ? $search['tag'] : [$search['tag']]);
 
             if (!empty($tags)) {
                 $query->whereHas('tags', function (Builder $query) use ($tags) {

--- a/src/Rules/ValidAuthor.php
+++ b/src/Rules/ValidAuthor.php
@@ -26,6 +26,8 @@ class ValidAuthor implements Rule
         if (is_null($user) || !$user->can('create', Course::class)) {
             return false;
         }
+
+        return true;
     }
 
     /**

--- a/src/Rules/ValidAuthor.php
+++ b/src/Rules/ValidAuthor.php
@@ -17,13 +17,15 @@ class ValidAuthor implements Rule
      */
     public function passes($attribute, $value)
     {
-        if (!is_null($value)) {
-            $user = Auth::user()->find($value);
-            if (is_null($user) || !$user->can('create', Course::class)) {
-                return false;
-            }
+        if (is_null($value)) {
+            return false;
         }
-        return true;
+
+        $user = Auth::user()->find($value);
+
+        if (is_null($user) || !$user->can('create', Course::class)) {
+            return false;
+        }
     }
 
     /**

--- a/src/Services/CourseService.php
+++ b/src/Services/CourseService.php
@@ -51,7 +51,7 @@ class CourseService implements CourseServiceContract
             $search,
             $criteria
         )->with(['categories', 'tags', 'authors'])
-            ->withCount(['lessons', 'users', 'topics']);
+            ->withCount(['lessons', 'users', 'topics', 'authors']);
 
         return $query;
     }

--- a/tests/APIs/CourseAdminApiTest.php
+++ b/tests/APIs/CourseAdminApiTest.php
@@ -203,6 +203,29 @@ class CourseAdminApiTest extends TestCase
         $this->response->assertInvalid('authors.0');
     }
 
+    public function test_update_course_remove_authors()
+    {
+        $course = Course::factory()->create([
+            'author_id' => $this->user->getKey()
+        ]);
+
+        $this->assertNotEquals([], $course->authors->toArray());
+
+        $editedCourse = Course::factory()->make()->toArray();
+        $editedCourse['authors'] = [];
+
+        $this->response = $this->actingAs($this->user, 'api')->json(
+            'PUT',
+            '/api/admin/courses/' . $course->id,
+            $editedCourse
+        );
+
+        $this->response->assertOk();
+
+        $course->refresh();
+        $this->assertEquals([], $course->authors->toArray());
+    }
+
     /**
      * @test
      */

--- a/tests/APIs/CourseProgressApiTest.php
+++ b/tests/APIs/CourseProgressApiTest.php
@@ -20,6 +20,7 @@ use EscolaLms\Courses\Tests\ProgressConfigurable;
 use EscolaLms\Courses\Tests\TestCase;
 use EscolaLms\Courses\ValueObjects\CourseProgressCollection;
 use EscolaLms\Tags\Models\Tag;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
@@ -30,6 +31,7 @@ use Illuminate\Support\Facades\Queue;
 class CourseProgressApiTest extends TestCase
 {
     use CreatesUsers, WithFaker, ProgressConfigurable, MakeServices;
+    use DatabaseTransactions;
 
     public function test_show_progress_courses()
     {

--- a/tests/APIs/CourseProgressApiTest.php
+++ b/tests/APIs/CourseProgressApiTest.php
@@ -165,22 +165,25 @@ class CourseProgressApiTest extends TestCase
     public function test_ping_progress_course()
     {
         $user = User::factory()->create();
-        $courses = Course::factory(5)->create(['active' => true]);
+        $course = Course::factory()->create(['active' => true]);
+        $lesson = Lesson::factory()->create(['course_id' => $course->getKey()]);
         $topics = Topic::factory(2)->create([
             'active' => true,
+            'lesson_id' => $lesson->getKey(),
         ]);
+
+        $user->courses()->sync([$course]);
+
         $oneTopic = null;
-        foreach ($courses as $course) {
-            foreach ($topics as $topic) {
-                $oneTopic = $topic;
-                CourseProgress::create([
-                    'user_id' => $user->getKey(),
-                    'topic_id' => $topic->getKey(),
-                    'status' => 0
-                ]);
-            }
-            $user->courses()->save($course);
+        foreach ($topics as $topic) {
+            $oneTopic = $topic;
+            CourseProgress::create([
+                'user_id' => $user->getKey(),
+                'topic_id' => $topic->getKey(),
+                'status' => 0
+            ]);
         }
+
         $this->response = $this->actingAs($user, 'api')->json(
             'PUT',
             '/api/courses/progress/' . $oneTopic->getKey() . '/ping'

--- a/tests/APIs/CourseProgressApiTest.php
+++ b/tests/APIs/CourseProgressApiTest.php
@@ -164,6 +164,7 @@ class CourseProgressApiTest extends TestCase
 
     public function test_ping_progress_course()
     {
+        /** @var User $user */
         $user = User::factory()->create();
         $course = Course::factory()->create(['active' => true]);
         $lesson = Lesson::factory()->create(['course_id' => $course->getKey()]);
@@ -172,7 +173,7 @@ class CourseProgressApiTest extends TestCase
             'lesson_id' => $lesson->getKey(),
         ]);
 
-        $user->courses()->sync([$course]);
+        $user->courses()->sync([$course->getKey()]);
 
         $oneTopic = null;
         foreach ($topics as $topic) {

--- a/tests/APIs/CourseTutorRestrictApiTest.php
+++ b/tests/APIs/CourseTutorRestrictApiTest.php
@@ -5,13 +5,12 @@ namespace EscolaLms\Courses\Tests\APIs;
 use EscolaLms\Categories\Models\Category;
 use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
 use EscolaLms\Courses\Models\Course;
-use EscolaLms\Courses\Models\User;
 use EscolaLms\Courses\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class CourseTutorRestrictApiTest extends TestCase
 {
-    use /*ApiTestTrait,*/ DatabaseTransactions;
+    use DatabaseTransactions;
 
     /**
      * @test

--- a/tests/APIs/LessonAnonymousApiTest.php
+++ b/tests/APIs/LessonAnonymousApiTest.php
@@ -2,15 +2,13 @@
 
 namespace EscolaLms\Courses\Tests\APIs;
 
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use EscolaLms\Courses\Tests\TestCase;
-//use Tests\ApiTestTrait;
 use EscolaLms\Courses\Models\Lesson;
+use EscolaLms\Courses\Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class LessonAnonymousApiTest extends TestCase
 {
-    use /*ApiTestTrait,*/ DatabaseTransactions;
+    use DatabaseTransactions;
 
     /**
      * @test

--- a/tests/APIs/LessonAnonymousApiTest.php
+++ b/tests/APIs/LessonAnonymousApiTest.php
@@ -2,6 +2,7 @@
 
 namespace EscolaLms\Courses\Tests\APIs;
 
+use EscolaLms\Courses\Models\Course;
 use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -9,6 +10,12 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class LessonAnonymousApiTest extends TestCase
 {
     use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Course::factory()->create(); // Lesson factory requires at least one Course existing in DB
+    }
 
     /**
      * @test

--- a/tests/APIs/LessonTutorApiTest.php
+++ b/tests/APIs/LessonTutorApiTest.php
@@ -2,19 +2,17 @@
 
 namespace EscolaLms\Courses\Tests\APIs;
 
+use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
+use EscolaLms\Courses\Models\Course;
+use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Models\Topic;
 use EscolaLms\Courses\Tests\Models\TopicContent\ExampleTopicType;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use EscolaLms\Courses\Tests\TestCase;
-use EscolaLms\Courses\Models\Lesson;
-use EscolaLms\Courses\Models\Course;
-
-use EscolaLms\Courses\Database\Seeders\CoursesPermissionSeeder;
-use Illuminate\Support\Facades\Event;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class LessonTutorApiTest extends TestCase
 {
-    use /*ApiTestTrait,*/ DatabaseTransactions;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/APIs/TopicTutorApiTest.php
+++ b/tests/APIs/TopicTutorApiTest.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Storage;
 
 class TopicTutorApiTest extends TestCase
 {
-    use /*ApiTestTrait,*/ DatabaseTransactions;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/APIs/TopicTutorUpdateApiTest.php
+++ b/tests/APIs/TopicTutorUpdateApiTest.php
@@ -41,7 +41,7 @@ class TopicTutorUpdateApiTest extends TestCase
             'Content' => 'application/x-www-form-urlencoded',
             'Accept' => 'application/json',
         ])->actingAs($this->user, 'api')->post(
-            '/api/admin/topics/'.$this->topic->id,
+            '/api/admin/topics/' . $this->topic->id,
             [
                 'title' => 'Hello World',
                 'lesson_id' => $this->topic->lesson_id,

--- a/tests/APIs/TopicTutorUpdateApiTest.php
+++ b/tests/APIs/TopicTutorUpdateApiTest.php
@@ -8,11 +8,7 @@ use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Models\Topic;
 use EscolaLms\Courses\Tests\Models\TopicContent\ExampleTopicType;
 use EscolaLms\Courses\Tests\TestCase;
-use EscolaLms\TopicTypes\Events\VideoUpdated;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Storage;
 
 class TopicTutorUpdateApiTest extends TestCase
 {

--- a/tests/Repositories/CourseRepositoryTest.php
+++ b/tests/Repositories/CourseRepositoryTest.php
@@ -16,7 +16,7 @@ class CourseRepositoryTest extends TestCase
      */
     protected $courseRepo;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->courseRepo = \App::make(CourseRepository::class);

--- a/tests/Repositories/LessonRepositoryTest.php
+++ b/tests/Repositories/LessonRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace EscolaLms\Courses\Tests\Repositories;
 
+use EscolaLms\Courses\Models\Course;
 use EscolaLms\Courses\Models\Lesson;
 use EscolaLms\Courses\Repositories\LessonRepository;
 use EscolaLms\Courses\Tests\TestCase;
@@ -16,10 +17,11 @@ class LessonRepositoryTest extends TestCase
      */
     protected $lessonRepo;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->lessonRepo = \App::make(LessonRepository::class);
+        Course::factory()->create(); // Lesson factory requires at least one Course existing in DB
     }
 
     /**

--- a/tests/Repositories/TopicRepositoryTest.php
+++ b/tests/Repositories/TopicRepositoryTest.php
@@ -24,7 +24,7 @@ class TopicRepositoryTest extends TestCase
      */
     protected $topicRepo;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->topicRepo = \App::make(TopicRepositoryContract::class);
@@ -75,7 +75,9 @@ class TopicRepositoryTest extends TestCase
      */
     public function testReadTopic()
     {
-        $topic = Topic::factory()->create();
+        $course = Course::factory()->create();
+        $lesson = Lesson::factory()->create(['course_id' => $course->getKey()]);
+        $topic = Topic::factory()->create(['lesson_id' => $lesson->getKey()]);
 
         $dbTopic = $this->topicRepo->find($topic->id);
 
@@ -172,7 +174,9 @@ class TopicRepositoryTest extends TestCase
      */
     public function testDeleteTopic()
     {
-        $topic = Topic::factory()->create();
+        $course = Course::factory()->create();
+        $lesson = Lesson::factory()->create(['course_id' => $course->getKey()]);
+        $topic = Topic::factory()->create(['lesson_id' => $lesson->getKey()]);
 
         $resp = $this->topicRepo->delete($topic->id);
 


### PR DESCRIPTION
There was no `use DatabaseTransaction` in one of the test files and many other tests passed only because there were persisted Courses and Lessons in database... This PR fixes all tests to work with clean db.